### PR TITLE
Hide state setting objects

### DIFF
--- a/XUSG-EZ/XUSG-EZ.cpp
+++ b/XUSG-EZ/XUSG-EZ.cpp
@@ -249,4 +249,3 @@ EZ::RayTracing::CommandList::sptr EZ::RayTracing::CommandList::MakeShared(XUSG::
 		maxSamplers, pMaxCbvsEachSpace, pMaxSrvsEachSpace, pMaxUavsEachSpace,
 		maxCbvSpaces, maxSrvSpaces, maxUavSpaces);
 }
-

--- a/XUSG-EZ/XUSG-EZ.h
+++ b/XUSG-EZ/XUSG-EZ.h
@@ -82,12 +82,21 @@ namespace XUSG
 				TileCopyFlag flags) = 0;
 			virtual void ResolveSubresource(Resource* pDstResource, uint32_t dstSubresource,
 				Resource* pSrcResource, uint32_t srcSubresource, Format format) = 0;
+			virtual void IASetInputLayout(const InputLayout* pLayout) = 0;
+			virtual void IASetIndexBufferStripCutValue(IBStripCutValue ibStripCutValue) = 0;
 			virtual void RSSetState(Graphics::RasterizerPreset preset) = 0;
 			virtual void RSSetViewports(uint32_t numViewports, const Viewport* pViewports) const = 0;
 			virtual void RSSetScissorRects(uint32_t numRects, const RectRange* pRects) const = 0;
+			virtual void OMSetBlendState(Graphics::BlendPreset preset,
+				uint8_t numColorRTs = 1, uint32_t sampleMask = UINT_MAX) = 0;
 			virtual void OMSetBlendFactor(const float blendFactor[4]) const = 0;
 			virtual void OMSetStencilRef(uint32_t stencilRef) const = 0;
+			virtual void OMSetSample(uint8_t count, uint8_t quality = 0) = 0;
 			virtual void DSSetState(Graphics::DepthStencilPreset preset) = 0;
+			virtual void SetGraphicsShader(Shader::Stage stage, const Blob& shader) = 0;
+			virtual void SetGraphicsNodeMask(uint32_t nodeMask) = 0;
+			virtual void SetComputeShader(const Blob& shader) = 0;
+			virtual void SetComputeNodeMask(uint32_t nodeMask) = 0;
 			virtual void SetPipelineState(const Pipeline& pipelineState) = 0;
 			virtual void ExecuteBundle(const XUSG::CommandList* pCommandList) const = 0;
 			virtual void SetGraphicsSamplerStates(uint32_t startBinding, uint32_t numSamplers, const SamplerPreset* pSamplerPresets) = 0;
@@ -138,9 +147,6 @@ namespace XUSG
 			virtual void* GetDeviceHandle() const = 0;
 
 			virtual const Device* GetDevice() const = 0;
-
-			virtual Graphics::State* GetGraphicsPipelineState() = 0;
-			virtual Compute::State* GetComputePipelineState() = 0;
 
 			using uptr = std::unique_ptr<CommandList>;
 			using sptr = std::shared_ptr<CommandList>;

--- a/XUSG-EZ/XUSG-EZ.h
+++ b/XUSG-EZ/XUSG-EZ.h
@@ -5,7 +5,10 @@
 #pragma once
 
 #include "Core/XUSG.h"
+
+#ifdef XUSG_RAY_TRACING_EZ
 #include "RayTracing/XUSGRayTracing.h"
+#endif
 
 namespace XUSG
 {
@@ -163,6 +166,7 @@ namespace XUSG
 				XUSG::API api = XUSG::API::DIRECTX_12);
 		};
 
+#ifdef XUSG_RAY_TRACING_EZ
 		namespace RayTracing
 		{
 			//--------------------------------------------------------------------------------------
@@ -209,5 +213,6 @@ namespace XUSG
 					XUSG::API api = XUSG::API::DIRECTX_12);
 			};
 		}
+#endif
 	}
 }

--- a/XUSG-EZ/XUSG-EZ_DX12.h
+++ b/XUSG-EZ/XUSG-EZ_DX12.h
@@ -54,6 +54,8 @@ namespace XUSG
 				TileCopyFlag flags);
 			void ResolveSubresource(Resource* pDstResource, uint32_t dstSubresource,
 				Resource* pSrcResource, uint32_t srcSubresource, Format format);
+			void IASetInputLayout(const InputLayout* pLayout);
+			void IASetIndexBufferStripCutValue(IBStripCutValue ibStripCutValue);
 			void RSSetState(Graphics::RasterizerPreset preset);
 			void RSSetViewports(uint32_t numViewports, const Viewport* pViewports) const
 			{
@@ -65,9 +67,15 @@ namespace XUSG
 				XUSG::CommandList_DX12::RSSetScissorRects(numRects, pRects);
 			}
 
+			void OMSetBlendState(Graphics::BlendPreset preset, uint8_t numColorRTs = 1, uint32_t sampleMask = UINT_MAX);
 			void OMSetBlendFactor(const float blendFactor[4]) const { XUSG::CommandList_DX12::OMSetBlendFactor(blendFactor); }
 			void OMSetStencilRef(uint32_t stencilRef) const { XUSG::CommandList_DX12::OMSetStencilRef(stencilRef); }
+			void OMSetSample(uint8_t count, uint8_t quality = 0);
 			void DSSetState(Graphics::DepthStencilPreset preset);
+			void SetGraphicsShader(Shader::Stage stage, const Blob& shader);
+			void SetGraphicsNodeMask(uint32_t nodeMask);
+			void SetComputeShader(const Blob& shader);
+			void SetComputeNodeMask(uint32_t nodeMask);
 			void SetPipelineState(const Pipeline& pipelineState);
 			void ExecuteBundle(const XUSG::CommandList* pCommandList) const { XUSG::CommandList_DX12::ExecuteBundle(pCommandList); }
 			void SetGraphicsSamplerStates(uint32_t startBinding, uint32_t numSamplers, const SamplerPreset* pSamplerPresets);
@@ -158,9 +166,6 @@ namespace XUSG
 
 			const Device* GetDevice() const { return XUSG::CommandList_DX12::GetDevice(); }
 
-			Graphics::State* GetGraphicsPipelineState();
-			Compute::State* GetComputePipelineState();
-
 		protected:
 			enum PipelineLayoutIndex
 			{
@@ -211,6 +216,9 @@ namespace XUSG
 
 			Graphics::State::uptr m_graphicsState;
 			Compute::State::uptr m_computeState;
+
+			uint32_t m_isGraphicsDirty;
+			uint32_t m_isComputeDirty;
 
 			std::vector<Descriptor> m_descriptors;
 			std::vector<Util::DescriptorTable::uptr> m_graphicsCbvSrvUavTables[Shader::Stage::NUM_GRAPHICS][CbvSrvUavTypes];

--- a/XUSG-EZ/stdafx.h
+++ b/XUSG-EZ/stdafx.h
@@ -59,3 +59,4 @@
 #endif  // _DEBUG
 
 #define ENABLE_DXR_FALLBACK 1
+#define XUSG_RAY_TRACING_EZ


### PR DESCRIPTION
1. Add dirty values to reduce the accesses to pipeline management cache.
2. Hide state setting objects to avoid developer storing them.