### PR TITLE
Fix RayTracing-EZ

### DIFF
--- a/XUSG-EZ/XUSG-EZ.h
+++ b/XUSG-EZ/XUSG-EZ.h
@@ -51,6 +51,10 @@ namespace XUSG
 			virtual bool Create(XUSG::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 				uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 				const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1) = 0;
+			virtual bool Create(const Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+				uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
+				const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
+				const wchar_t* name = nullptr) = 0;
 			virtual bool Close() const = 0;
 			virtual bool Reset(const CommandAllocator* pAllocator, const Pipeline& initialState) = 0;
 
@@ -137,29 +141,25 @@ namespace XUSG
 			virtual void ResetDescriptorPool(DescriptorPoolType type) = 0;
 			virtual void Resize() = 0;
 
-			virtual bool Create(const Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
-				uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
-				const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
-				const wchar_t* name = nullptr) = 0;
-
 			virtual void* GetHandle() const = 0;
 			virtual void* GetDeviceHandle() const = 0;
 
 			virtual const Device* GetDevice() const = 0;
+			virtual XUSG::CommandList* AsCommandList() = 0;
 
 			using uptr = std::unique_ptr<CommandList>;
 			using sptr = std::shared_ptr<CommandList>;
 
-			static uptr MakeUnique(XUSG::API api = XUSG::API::DIRECTX_12);
-			static sptr MakeShared(XUSG::API api = XUSG::API::DIRECTX_12);
+			static uptr MakeUnique(API api = API::DIRECTX_12);
+			static sptr MakeShared(API api = API::DIRECTX_12);
 			static uptr MakeUnique(XUSG::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 				uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 				const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
-				XUSG::API api = XUSG::API::DIRECTX_12);
+				API api = API::DIRECTX_12);
 			static sptr MakeShared(XUSG::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 				uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 				const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
-				XUSG::API api = XUSG::API::DIRECTX_12);
+				API api = API::DIRECTX_12);
 		};
 	}
 }

--- a/XUSG-EZ/XUSG-EZ_DX12.cpp
+++ b/XUSG-EZ/XUSG-EZ_DX12.cpp
@@ -74,6 +74,18 @@ bool EZ::CommandList_DX12::Create(XUSG::CommandList* pCommandList, uint32_t samp
 	return true;
 }
 
+bool EZ::CommandList_DX12::Create(const Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+	uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace, const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
+	uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces, const wchar_t* name)
+{
+	m_pDevice = pDevice;
+	XUSG::CommandList_DX12::Create(pHandle, name);
+
+	return Create(this, samplerPoolSize, cbvSrvUavPoolSize, maxSamplers,
+		pMaxCbvsEachSpace, pMaxSrvsEachSpace, pMaxUavsEachSpace,
+		maxCbvSpaces, maxSrvSpaces, maxUavSpaces);
+}
+
 bool EZ::CommandList_DX12::Reset(const CommandAllocator* pAllocator, const Pipeline& initialState)
 {
 	const auto ret = XUSG::CommandList_DX12::Reset(pAllocator, initialState);
@@ -481,18 +493,6 @@ void EZ::CommandList_DX12::ResetDescriptorPool(DescriptorPoolType type)
 void EZ::CommandList_DX12::Resize()
 {
 	ResetDescriptorPool(DescriptorPoolType::CBV_SRV_UAV_POOL);
-}
-
-bool EZ::CommandList_DX12::Create(const Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
-	uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace, const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
-	uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces, const wchar_t* name)
-{
-	m_pDevice = pDevice;
-	XUSG::CommandList_DX12::Create(pHandle, name);
-
-	return Create(this, samplerPoolSize, cbvSrvUavPoolSize, maxSamplers,
-		pMaxCbvsEachSpace, pMaxSrvsEachSpace, pMaxUavsEachSpace,
-		maxCbvSpaces, maxSrvSpaces, maxUavSpaces);
 }
 
 bool EZ::CommandList_DX12::createPipelineLayouts(uint32_t maxSamplers,

--- a/XUSG-EZ/XUSG-EZ_DX12.h
+++ b/XUSG-EZ/XUSG-EZ_DX12.h
@@ -24,6 +24,10 @@ namespace XUSG
 			bool Create(XUSG::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 				uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 				const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1);
+			bool Create(const Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+				uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
+				const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
+				const wchar_t* name = nullptr);
 			bool Close() const { return XUSG::CommandList_DX12::Close(); }
 			bool Reset(const CommandAllocator* pAllocator, const Pipeline& initialState);
 
@@ -156,15 +160,11 @@ namespace XUSG
 			void ResetDescriptorPool(DescriptorPoolType type);
 			void Resize();
 
-			bool Create(const Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
-				uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
-				const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
-				const wchar_t* name = nullptr);
-
 			void* GetHandle() const { return XUSG::CommandList_DX12::GetHandle(); }
 			void* GetDeviceHandle() const { return XUSG::CommandList_DX12::GetDeviceHandle(); }
 
 			const Device* GetDevice() const { return XUSG::CommandList_DX12::GetDevice(); }
+			XUSG::CommandList* AsCommandList() { return dynamic_cast<XUSG::CommandList*>(this); }
 
 		protected:
 			enum PipelineLayoutIndex

--- a/XUSGRayTracing-EZ/XUSGRayTracing-EZ.h
+++ b/XUSGRayTracing-EZ/XUSGRayTracing-EZ.h
@@ -26,41 +26,45 @@ namespace XUSG
 				using uptr = std::unique_ptr<CommandList>;
 				using sptr = std::shared_ptr<CommandList>;
 
-				virtual bool Create(XUSG::RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+				virtual bool Create(RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
 					uint32_t maxTLASSrvs = 0, uint32_t spaceTLAS = 0) = 0;
-				virtual bool Create(const XUSG::RayTracing::Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+				virtual bool Create(const RayTracing::Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
-					const wchar_t* name = nullptr) = 0;
+					uint32_t maxTLASSrvs = 0, uint32_t spaceTLAS = 0, const wchar_t* name = nullptr) = 0;
 				virtual bool Close() = 0;
-				virtual bool PreBuildBLAS(XUSG::RayTracing::BottomLevelAS* pBLAS, uint32_t numGeometries, const XUSG::RayTracing::GeometryBuffer& geometries,
-					XUSG::RayTracing::BuildFlag flags = XUSG::RayTracing::BuildFlag::PREFER_FAST_TRACE) = 0;
-				virtual bool PreBuildTLAS(XUSG::RayTracing::TopLevelAS* pTLAS, uint32_t numInstances, XUSG::RayTracing::BuildFlag flags) = 0;
+				virtual bool PreBuildBLAS(BottomLevelAS* pBLAS, uint32_t numGeometries, const GeometryBuffer& geometries,
+					BuildFlag flags = BuildFlag::PREFER_FAST_TRACE) = 0;
+				virtual bool PreBuildTLAS(TopLevelAS* pTLAS, uint32_t numInstances,
+					BuildFlag flags = BuildFlag::PREFER_FAST_TRACE) = 0;
 
-				virtual void BuildBLAS(XUSG::RayTracing::BottomLevelAS* pBLAS, bool update = false) = 0;
-				virtual void BuildTLAS(XUSG::RayTracing::TopLevelAS* pTLAS, const Resource* pInstanceDescs, bool update = false) = 0;
-				virtual void SetTopLevelAccelerationStructure(uint32_t binding, const XUSG::RayTracing::TopLevelAS* pTopLevelAS) const = 0;
+				virtual void BuildBLAS(BottomLevelAS* pBLAS, bool update = false) = 0;
+				virtual void BuildTLAS(TopLevelAS* pTLAS, const Resource* pInstanceDescs, bool update = false) = 0;
+				virtual void SetTopLevelAccelerationStructure(uint32_t binding, const TopLevelAS* pTopLevelAS) const = 0;
 				virtual void RTSetShaderLibrary(Blob shaderLib) = 0;
 				virtual void RTSetHitGroup(uint32_t index, const void* hitGroup, const void* closestHitShader,
 					const void* anyHitShader = nullptr, const void* intersectionShader = nullptr,
-					XUSG::RayTracing::HitGroupType type = XUSG::RayTracing::HitGroupType::TRIANGLES) = 0;
+					HitGroupType type = HitGroupType::TRIANGLES) = 0;
 				virtual void RTSetShaderConfig(uint32_t maxPayloadSize, uint32_t maxAttributeSize = sizeof(float[2])) = 0;
 				virtual void RTSetMaxRecursionDepth(uint32_t depth) = 0;
 				virtual void DispatchRays(uint32_t width, uint32_t height, uint32_t depth,
 					const void* rayGenShader, const void* missShader) = 0;
 
-				static uptr MakeUnique(XUSG::API api = XUSG::API::DIRECTX_12);
-				static sptr MakeShared(XUSG::API api = XUSG::API::DIRECTX_12);
-				static uptr MakeUnique(XUSG::RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+				virtual const Device* GetRTDevice() const = 0;
+				virtual RayTracing::CommandList* AsRTCommandList() = 0;
+
+				static uptr MakeUnique(API api = API::DIRECTX_12);
+				static sptr MakeShared(API api = API::DIRECTX_12);
+				static uptr MakeUnique(RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
-					XUSG::API api = XUSG::API::DIRECTX_12);
-				static sptr MakeShared(XUSG::RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+					API api = API::DIRECTX_12);
+				static sptr MakeShared(RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
-					XUSG::API api = XUSG::API::DIRECTX_12);
+					API api = API::DIRECTX_12);
 			};
 		}
 	}

--- a/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.cpp
+++ b/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.cpp
@@ -69,14 +69,14 @@ bool EZ::CommandList_DXR::Create(RayTracing::CommandList* pCommandList, uint32_t
 
 bool EZ::CommandList_DXR::Create(const RayTracing::Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 	uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace, const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
-	uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces, const wchar_t* name)
+	uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces, uint32_t maxTLASSrvs, uint32_t spaceTLAS, const wchar_t* name)
 {
 	m_pDeviceRT = pDevice;
 	RayTracing::CommandList_DX12::Create(pHandle, name);
 
 	return Create(this, samplerPoolSize, cbvSrvUavPoolSize, maxSamplers,
 		pMaxCbvsEachSpace, pMaxSrvsEachSpace, pMaxUavsEachSpace,
-		maxCbvSpaces, maxSrvSpaces, maxUavSpaces);
+		maxCbvSpaces, maxSrvSpaces, maxUavSpaces, maxTLASSrvs, spaceTLAS);
 }
 
 bool EZ::CommandList_DXR::Close()

--- a/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.h
+++ b/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.h
@@ -19,36 +19,40 @@ namespace XUSG
 			{
 			public:
 				CommandList_DXR();
-				CommandList_DXR(XUSG::RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+				CommandList_DXR(RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
 					uint32_t maxTLASSrvs = 0, uint32_t spaceTLAS = 0);
 				virtual ~CommandList_DXR();
 
-				bool Create(XUSG::RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+				bool Create(RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
 					uint32_t maxTLASSrvs = 0, uint32_t spaceTLAS = 0);
-				bool Close();
-				bool PreBuildBLAS(XUSG::RayTracing::BottomLevelAS* pBLAS, uint32_t numGeometries, const XUSG::RayTracing::GeometryBuffer& geometries,
-					XUSG::RayTracing::BuildFlag flags = XUSG::RayTracing::BuildFlag::PREFER_FAST_TRACE);
-				bool PreBuildTLAS(XUSG::RayTracing::TopLevelAS* pTLAS, uint32_t numInstances, XUSG::RayTracing::BuildFlag flags);
-				bool Create(const XUSG::RayTracing::Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+				bool Create(const RayTracing::Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
-					const wchar_t* name = nullptr);
+					uint32_t maxTLASSrvs = 0, uint32_t spaceTLAS = 0, const wchar_t* name = nullptr);
+				bool Close();
+				bool PreBuildBLAS(BottomLevelAS* pBLAS, uint32_t numGeometries, const GeometryBuffer& geometries,
+					BuildFlag flags = BuildFlag::PREFER_FAST_TRACE);
+				bool PreBuildTLAS(TopLevelAS* pTLAS, uint32_t numInstances,
+					BuildFlag flags = BuildFlag::PREFER_FAST_TRACE);
 
-				void BuildBLAS(XUSG::RayTracing::BottomLevelAS* pBLAS, bool update = false);
-				void BuildTLAS(XUSG::RayTracing::TopLevelAS* pTLAS, const Resource* pInstanceDescs, bool update = false);
-				void SetTopLevelAccelerationStructure(uint32_t index, const XUSG::RayTracing::TopLevelAS* pTopLevelAS) const;
+				void BuildBLAS(BottomLevelAS* pBLAS, bool update = false);
+				void BuildTLAS(TopLevelAS* pTLAS, const Resource* pInstanceDescs, bool update = false);
+				void SetTopLevelAccelerationStructure(uint32_t index, const TopLevelAS* pTopLevelAS) const;
 				void RTSetShaderLibrary(Blob shaderLib);
 				void RTSetShaderConfig(uint32_t maxPayloadSize, uint32_t maxAttributeSize = sizeof(float[2]));
 				void RTSetHitGroup(uint32_t index, const void* hitGroup, const void* closestHitShader,
 					const void* anyHitShader = nullptr, const void* intersectionShader = nullptr,
-					XUSG::RayTracing::HitGroupType type = XUSG::RayTracing::HitGroupType::TRIANGLES);
+					HitGroupType type = HitGroupType::TRIANGLES);
 				void RTSetMaxRecursionDepth(uint32_t depth);
 				void DispatchRays(uint32_t width, uint32_t height, uint32_t depth,
 					const void* rayGenShader, const void* missShader);
+
+				const Device* GetRTDevice() const { return RayTracing::CommandList_DX12::GetRTDevice(); }
+				RayTracing::CommandList* AsRTCommandList() { return dynamic_cast<RayTracing::CommandList*>(this); }
 
 			protected:
 				bool createPipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
@@ -56,30 +60,30 @@ namespace XUSG
 					uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces,
 					uint32_t maxTLASSrvs, uint32_t spaceTLAS);
 
-				XUSG::Resource* needScratch(uint32_t size);
+				Resource* needScratch(uint32_t size);
 
-				const void* getHitGroupFromState(uint32_t index, const XUSG::RayTracing::State* pState);
+				const void* getHitGroupFromState(uint32_t index, const RayTracing::State* pState);
 
-				uint32_t getNumHitGroupsFromState(const XUSG::RayTracing::State* pState);
+				uint32_t getNumHitGroupsFromState(const RayTracing::State* pState);
 
-				const XUSG::RayTracing::ShaderTable* getShaderTable(const std::string& key,
-					std::unordered_map<std::string, XUSG::RayTracing::ShaderTable::uptr>& shaderTables,
+				const ShaderTable* getShaderTable(const std::string& key,
+					std::unordered_map<std::string, ShaderTable::uptr>& shaderTables,
 					uint32_t numShaderIDs);
 
-				XUSG::RayTracing::PipelineCache::uptr m_RayTracingPipelineCache;
+				RayTracing::PipelineCache::uptr m_RayTracingPipelineCache;
 
 				uint32_t m_scratchSize;
-				std::vector<XUSG::Resource::uptr> m_scratches;
+				std::vector<Resource::uptr> m_scratches;
 
 				bool m_isRTStateDirty;
-				XUSG::RayTracing::State::uptr m_rayTracingState;
+				RayTracing::State::uptr m_rayTracingState;
 
 				uint32_t m_asUavCount;
 				std::vector<uint32_t> m_tlasBindingToParamIndexMap;
 
-				std::unordered_map<std::string, XUSG::RayTracing::ShaderTable::uptr> m_rayGenTables;
-				std::unordered_map<std::string, XUSG::RayTracing::ShaderTable::uptr> m_hitGroupTables;
-				std::unordered_map<std::string, XUSG::RayTracing::ShaderTable::uptr> m_missTables;
+				std::unordered_map<std::string, ShaderTable::uptr> m_rayGenTables;
+				std::unordered_map<std::string, ShaderTable::uptr> m_hitGroupTables;
+				std::unordered_map<std::string, ShaderTable::uptr> m_missTables;
 			};
 		}
 	}


### PR DESCRIPTION
1. Add missing interfaces to get XUSG device and XUSG command list.
2. Fix Create with native DX12 handle.
3. Shorten code.
4. Adjust function order.