### PR TITLE
EZ crash fix

### DIFF
--- a/XUSG-EZ/XUSG-EZ.h
+++ b/XUSG-EZ/XUSG-EZ.h
@@ -48,6 +48,7 @@ namespace XUSG
 			//CommandList();
 			virtual ~CommandList() {}
 
+			// By default maxCbvsEachSpace = 14, maxSrvsEachSpace = 32, and maxUavsEachSpace = 16
 			virtual bool Create(XUSG::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 				uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 				const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1) = 0;

--- a/XUSGRayTracing-EZ/XUSGRayTracing-EZ.h
+++ b/XUSGRayTracing-EZ/XUSGRayTracing-EZ.h
@@ -26,6 +26,8 @@ namespace XUSG
 				using uptr = std::unique_ptr<CommandList>;
 				using sptr = std::shared_ptr<CommandList>;
 
+				// By default maxCbvsEachSpace = 14 for graphics or 12 for ray tracing and compute
+				// maxSrvsEachSpace = 32, and maxUavsEachSpace = 16
 				virtual bool Create(RayTracing::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,

--- a/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.cpp
+++ b/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.cpp
@@ -47,6 +47,10 @@ bool EZ::CommandList_DXR::Create(RayTracing::CommandList* pCommandList, uint32_t
 	m_pDevice = m_pDeviceRT;
 	m_commandList = dynamic_cast<XUSG::CommandList_DX12*>(pCommandList)->GetGraphicsCommandList();
 
+	const auto pDxDevice = static_cast<ID3D12RaytracingFallbackDevice*>(m_pDeviceRT->GetRTHandle());
+	XUSG_N_RETURN(pDxDevice, false);
+	pDxDevice->QueryRaytracingCommandList(m_commandList.get(), IID_PPV_ARGS(&m_commandListRT));
+
 	m_graphicsPipelineCache = Graphics::PipelineCache::MakeUnique(m_pDevice, API::DIRECTX_12);
 	m_computePipelineCache = Compute::PipelineCache::MakeUnique(m_pDevice, API::DIRECTX_12);
 	m_RayTracingPipelineCache = PipelineCache::MakeUnique(m_pDeviceRT, API::DIRECTX_12);
@@ -338,7 +342,7 @@ bool EZ::CommandList_DXR::createPipelineLayouts(uint32_t maxSamplers, const uint
 		{
 			if (s < maxCbvSpaces)
 			{
-				const auto maxDescriptors = pMaxCbvsEachSpace ? pMaxCbvsEachSpace[s] : 14;
+				const auto maxDescriptors = pMaxCbvsEachSpace ? pMaxCbvsEachSpace[s] : 12;
 				m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::CBV)][s] = paramIndex;
 				pipelineLayout->SetRange(paramIndex++, DescriptorType::CBV, maxDescriptors, 0, s, DescriptorFlag::DATA_STATIC);
 			}


### PR DESCRIPTION
1. Fix missing m_commandListRT assignment that caused crash.
2. Set default maxCbvsEachSpace to 12, which is limited by Tier-2 (DXR fallback layer has taken 2 CBV slots).