### PR TITLE
XUSGUltimate preparation

### DIFF
--- a/XUSG-EZ/XUSG-EZ.vcxproj
+++ b/XUSG-EZ/XUSG-EZ.vcxproj
@@ -166,9 +166,11 @@
     <ClInclude Include="..\XUSG\Core\XUSG.h" />
     <ClInclude Include="..\XUSG\Core\XUSGCommand_DX12.h" />
     <ClInclude Include="..\XUSG\Core\XUSGEnum_DX12.h" />
+    <ClInclude Include="..\XUSG\Ultimate\XUSGUltimate.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="XUSG-EZ.h" />
     <ClInclude Include="XUSG-EZ_DX12.h" />
+    <ClInclude Include="XUSGUltimate-EZ.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\XUSG\Core\XUSGCommand_DX12.cpp">

--- a/XUSG-EZ/XUSG-EZ.vcxproj.filters
+++ b/XUSG-EZ/XUSG-EZ.vcxproj.filters
@@ -16,6 +16,9 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
+    <Filter Include="Ultimate">
+      <UniqueIdentifier>{5049027c-edea-4e7a-9af6-dbbea6e77bf9}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h">
@@ -35,6 +38,12 @@
     </ClInclude>
     <ClInclude Include="..\XUSG\Core\XUSGEnum_DX12.h">
       <Filter>Core</Filter>
+    </ClInclude>
+    <ClInclude Include="XUSGUltimate-EZ.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\XUSG\Ultimate\XUSGUltimate.h">
+      <Filter>Ultimate</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/XUSG-EZ/XUSG-EZ_DX12.cpp
+++ b/XUSG-EZ/XUSG-EZ_DX12.cpp
@@ -319,8 +319,8 @@ void EZ::CommandList_DX12::SetComputeNodeMask(uint32_t nodeMask)
 void EZ::CommandList_DX12::SetPipelineState(const Pipeline& pipelineState)
 {
 	XUSG::CommandList_DX12::SetPipelineState(pipelineState);
-	m_graphicsState.reset();
-	m_computeState.reset();
+	m_isGraphicsDirty = false;
+	m_isComputeDirty = false;
 }
 
 void EZ::CommandList_DX12::SetGraphicsSamplerStates(uint32_t startBinding, uint32_t numSamplers, const SamplerPreset* pSamplerPresets)
@@ -534,100 +534,116 @@ bool EZ::CommandList_DX12::createPipelineLayouts(uint32_t maxSamplers,
 	const uint32_t* pMaxCbvsEachSpace, const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
 	uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces)
 {
+	XUSG_N_RETURN(createGraphicsPipelineLayouts(maxSamplers, pMaxCbvsEachSpace, pMaxSrvsEachSpace,
+		pMaxUavsEachSpace, maxCbvSpaces, maxSrvSpaces, maxUavSpaces), false);
+
+	XUSG_N_RETURN(createComputePipelineLayouts(maxSamplers, pMaxCbvsEachSpace, pMaxSrvsEachSpace,
+		pMaxUavsEachSpace, maxCbvSpaces, maxSrvSpaces, maxUavSpaces), false);
+
+	return true;
+}
+
+bool EZ::CommandList_DX12::createGraphicsPipelineLayouts(uint32_t maxSamplers,
+	const uint32_t* pMaxCbvsEachSpace, const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
+	uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces)
+{
+	// Create common graphics pipeline layout
+	auto paramIndex = 0u;
+	const auto pipelineLayout = Util::PipelineLayout::MakeUnique(API::DIRECTX_12);
 	const auto maxSpaces = (max)(maxCbvSpaces, (max)(maxSrvSpaces, maxUavSpaces));
+	pipelineLayout->SetRange(paramIndex++, DescriptorType::SAMPLER, maxSamplers, 0, 0, DescriptorFlag::DATA_STATIC);
+
+	for (uint8_t i = 0; i < Shader::Stage::NUM_GRAPHICS; ++i)
 	{
-		// Create common graphics pipeline layout
-		auto paramIndex = 0u;
-		const auto pipelineLayout = Util::PipelineLayout::MakeUnique(API::DIRECTX_12);
-		const auto maxSpaces = (max)(maxCbvSpaces, (max)(maxSrvSpaces, maxUavSpaces));
-		pipelineLayout->SetRange(paramIndex++, DescriptorType::SAMPLER, maxSamplers, 0, 0, DescriptorFlag::DATA_STATIC);
-
-		for (uint8_t i = 0; i < Shader::Stage::NUM_GRAPHICS; ++i)
-		{
-			auto& descriptorTables = m_graphicsCbvSrvUavTables[i];
-			descriptorTables[static_cast<uint32_t>(DescriptorType::CBV)].resize(maxCbvSpaces);
-			descriptorTables[static_cast<uint32_t>(DescriptorType::SRV)].resize(maxSrvSpaces);
-			descriptorTables[static_cast<uint32_t>(DescriptorType::UAV)].resize(maxUavSpaces);
-
-			auto& spaceToParamIndexMap = m_graphicsSpaceToParamIndexMap[i];
-			spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::CBV)].resize(maxCbvSpaces);
-			spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::SRV)].resize(maxSrvSpaces);
-			spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::UAV)].resize(maxUavSpaces);
-			for (auto s = 0u; s < maxSpaces; ++s)
-			{
-				const auto stage = static_cast<Shader::Stage>(i);
-
-				if (s < maxCbvSpaces)
-				{
-					const auto maxDescriptors = pMaxCbvsEachSpace ? pMaxCbvsEachSpace[s] : 14;
-					spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::CBV)][s] = paramIndex;
-					pipelineLayout->SetRange(paramIndex, DescriptorType::CBV, maxDescriptors, 0, s, DescriptorFlag::DATA_STATIC);
-					pipelineLayout->SetShaderStage(paramIndex++, stage);
-				}
-
-				if (s < maxSrvSpaces)
-				{
-					const auto maxDescriptors = pMaxSrvsEachSpace ? pMaxSrvsEachSpace[s] : 32;
-					spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::SRV)][s] = paramIndex;
-					pipelineLayout->SetRange(paramIndex, DescriptorType::SRV, maxDescriptors, 0, s);
-					pipelineLayout->SetShaderStage(paramIndex++, stage);
-				}
-
-				if (s < maxUavSpaces)
-				{
-					const auto maxDescriptors = pMaxUavsEachSpace ? pMaxUavsEachSpace[s] : 16;
-					spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::UAV)][s] = paramIndex;
-					pipelineLayout->SetRange(paramIndex, DescriptorType::UAV, maxDescriptors, 0, s);
-					pipelineLayout->SetShaderStage(paramIndex++, stage);
-				}
-			}
-		}
-
-		XUSG_X_RETURN(m_pipelineLayouts[GRAPHICS], pipelineLayout->GetPipelineLayout(m_pipelineLayoutCache.get(),
-			PipelineLayoutFlag::ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT, L"EZGraphicsLayout"), false);
-	}
-
-	{
-		// Create common compute pipeline layout
-		auto paramIndex = 0u;
-		const auto pipelineLayout = Util::PipelineLayout::MakeUnique(API::DIRECTX_12);
-		pipelineLayout->SetRange(paramIndex++, DescriptorType::SAMPLER, maxSamplers, 0, 0, DescriptorFlag::DATA_STATIC);
-
-		auto& descriptorTables = m_computeCbvSrvUavTables;
+		auto& descriptorTables = m_graphicsCbvSrvUavTables[i];
 		descriptorTables[static_cast<uint32_t>(DescriptorType::CBV)].resize(maxCbvSpaces);
 		descriptorTables[static_cast<uint32_t>(DescriptorType::SRV)].resize(maxSrvSpaces);
 		descriptorTables[static_cast<uint32_t>(DescriptorType::UAV)].resize(maxUavSpaces);
 
-		m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::CBV)].resize(maxCbvSpaces);
-		m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::SRV)].resize(maxSrvSpaces);
-		m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::UAV)].resize(maxUavSpaces);
+		auto& spaceToParamIndexMap = m_graphicsSpaceToParamIndexMap[i];
+		spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::CBV)].resize(maxCbvSpaces);
+		spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::SRV)].resize(maxSrvSpaces);
+		spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::UAV)].resize(maxUavSpaces);
 		for (auto s = 0u; s < maxSpaces; ++s)
 		{
+			const auto stage = static_cast<Shader::Stage>(i);
+
 			if (s < maxCbvSpaces)
 			{
 				const auto maxDescriptors = pMaxCbvsEachSpace ? pMaxCbvsEachSpace[s] : 14;
-				m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::CBV)][s] = paramIndex;
-				pipelineLayout->SetRange(paramIndex++, DescriptorType::CBV, maxDescriptors, 0, s, DescriptorFlag::DATA_STATIC);
+				spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::CBV)][s] = paramIndex;
+				pipelineLayout->SetRange(paramIndex, DescriptorType::CBV, maxDescriptors, 0, s, DescriptorFlag::DATA_STATIC);
+				pipelineLayout->SetShaderStage(paramIndex++, stage);
 			}
 
 			if (s < maxSrvSpaces)
 			{
 				const auto maxDescriptors = pMaxSrvsEachSpace ? pMaxSrvsEachSpace[s] : 32;
-				m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::SRV)][s] = paramIndex;
-				pipelineLayout->SetRange(paramIndex++, DescriptorType::SRV, maxDescriptors, 0, s);
+				spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::SRV)][s] = paramIndex;
+				pipelineLayout->SetRange(paramIndex, DescriptorType::SRV, maxDescriptors, 0, s);
+				pipelineLayout->SetShaderStage(paramIndex++, stage);
 			}
 
 			if (s < maxUavSpaces)
 			{
 				const auto maxDescriptors = pMaxUavsEachSpace ? pMaxUavsEachSpace[s] : 16;
-				m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::UAV)][s] = paramIndex;
-				pipelineLayout->SetRange(paramIndex++, DescriptorType::UAV, maxDescriptors, 0, s);
+				spaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::UAV)][s] = paramIndex;
+				pipelineLayout->SetRange(paramIndex, DescriptorType::UAV, maxDescriptors, 0, s);
+				pipelineLayout->SetShaderStage(paramIndex++, stage);
 			}
 		}
-
-		XUSG_X_RETURN(m_pipelineLayouts[COMPUTE], pipelineLayout->GetPipelineLayout(m_pipelineLayoutCache.get(),
-			PipelineLayoutFlag::NONE, L"EZComputeLayout"), false);
 	}
+
+	XUSG_X_RETURN(m_pipelineLayouts[GRAPHICS], pipelineLayout->GetPipelineLayout(m_pipelineLayoutCache.get(),
+		PipelineLayoutFlag::ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT, L"EZGraphicsLayout"), false);
+
+	return true;
+}
+
+bool EZ::CommandList_DX12::createComputePipelineLayouts(uint32_t maxSamplers,
+	const uint32_t* pMaxCbvsEachSpace, const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
+	uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces)
+{
+	// Create common compute pipeline layout
+	auto paramIndex = 0u;
+	const auto pipelineLayout = Util::PipelineLayout::MakeUnique(API::DIRECTX_12);
+	const auto maxSpaces = (max)(maxCbvSpaces, (max)(maxSrvSpaces, maxUavSpaces));
+	pipelineLayout->SetRange(paramIndex++, DescriptorType::SAMPLER, maxSamplers, 0, 0, DescriptorFlag::DATA_STATIC);
+
+	auto& descriptorTables = m_computeCbvSrvUavTables;
+	descriptorTables[static_cast<uint32_t>(DescriptorType::CBV)].resize(maxCbvSpaces);
+	descriptorTables[static_cast<uint32_t>(DescriptorType::SRV)].resize(maxSrvSpaces);
+	descriptorTables[static_cast<uint32_t>(DescriptorType::UAV)].resize(maxUavSpaces);
+
+	m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::CBV)].resize(maxCbvSpaces);
+	m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::SRV)].resize(maxSrvSpaces);
+	m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::UAV)].resize(maxUavSpaces);
+	for (auto s = 0u; s < maxSpaces; ++s)
+	{
+		if (s < maxCbvSpaces)
+		{
+			const auto maxDescriptors = pMaxCbvsEachSpace ? pMaxCbvsEachSpace[s] : 14;
+			m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::CBV)][s] = paramIndex;
+			pipelineLayout->SetRange(paramIndex++, DescriptorType::CBV, maxDescriptors, 0, s, DescriptorFlag::DATA_STATIC);
+		}
+
+		if (s < maxSrvSpaces)
+		{
+			const auto maxDescriptors = pMaxSrvsEachSpace ? pMaxSrvsEachSpace[s] : 32;
+			m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::SRV)][s] = paramIndex;
+			pipelineLayout->SetRange(paramIndex++, DescriptorType::SRV, maxDescriptors, 0, s);
+		}
+
+		if (s < maxUavSpaces)
+		{
+			const auto maxDescriptors = pMaxUavsEachSpace ? pMaxUavsEachSpace[s] : 16;
+			m_computeSpaceToParamIndexMap[static_cast<uint32_t>(DescriptorType::UAV)][s] = paramIndex;
+			pipelineLayout->SetRange(paramIndex++, DescriptorType::UAV, maxDescriptors, 0, s);
+		}
+	}
+
+	XUSG_X_RETURN(m_pipelineLayouts[COMPUTE], pipelineLayout->GetPipelineLayout(m_pipelineLayoutCache.get(),
+		PipelineLayoutFlag::NONE, L"EZComputeLayout"), false);
 
 	return true;
 }

--- a/XUSG-EZ/XUSG-EZ_DX12.h
+++ b/XUSG-EZ/XUSG-EZ_DX12.h
@@ -195,6 +195,12 @@ namespace XUSG
 			bool createPipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
 				const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
 				uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces);
+			bool createGraphicsPipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
+				const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
+				uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces);
+			bool createComputePipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
+				const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
+				uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces);
 
 			void predraw();
 			void setBarriers(uint32_t numResources, const ResourceView* pResourceViews);

--- a/XUSG-EZ/XUSGUltimate-EZ.h
+++ b/XUSG-EZ/XUSGUltimate-EZ.h
@@ -1,0 +1,68 @@
+//--------------------------------------------------------------------------------------
+// Copyright (c) XU, Tianchen. All rights reserved.
+//--------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "XUSG-EZ.h"
+#include "Ultimate/XUSGUltimate.h"
+
+namespace XUSG
+{
+	namespace Ultimate
+	{
+		namespace EZ
+		{
+			//--------------------------------------------------------------------------------------
+			// RayTracing Command list
+			//--------------------------------------------------------------------------------------
+			class XUSG_INTERFACE CommandList :
+				public virtual XUSG::EZ::CommandList
+			{
+			public:
+				//CommandList();
+				virtual ~CommandList() {}
+
+				using uptr = std::unique_ptr<CommandList>;
+				using sptr = std::shared_ptr<CommandList>;
+
+				// By default maxCbvsEachSpace = 14, maxSrvsEachSpace = 32, and maxUavsEachSpace = 16
+				virtual bool Create(Ultimate::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
+					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1) = 0;
+				virtual bool Create(const Device* pDevice, void* pHandle, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
+					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
+					const wchar_t* name = nullptr) = 0;
+
+				virtual void SetSamplePositions(uint8_t numSamplesPerPixel, uint8_t numPixels, SamplePosition* pPositions) const = 0;
+				virtual void ResolveSubresourceRegion(const Resource* pDstResource, uint32_t dstSubresource,
+					uint32_t dstX, uint32_t dstY, const Resource* pSrcResource, uint32_t srcSubresource,
+					const RectRange& srcRect, Format format, ResolveMode resolveMode) const = 0;
+
+				virtual void RSSetShadingRate(ShadingRate baseShadingRate, const ShadingRateCombiner* pCombiners) const = 0;
+				virtual void RSSetShadingRateImage(const Resource* pShadingRateImage) const = 0;
+
+				virtual void SetPipelineState(const Pipeline& pipelineState) = 0;
+				virtual void MSSetBlendState(MeshShader::BlendPreset preset, uint8_t numColorRTs = 1, uint32_t sampleMask = UINT_MAX) = 0;
+				virtual void MSSetSample(uint8_t count, uint8_t quality = 0) = 0;
+				virtual void MSSetRasterizerState(MeshShader::RasterizerPreset preset) = 0;
+				virtual void MSSetDepthStencilState(MeshShader::DepthStencilPreset preset) = 0;
+				virtual void MSSetShader(Shader::Stage stage, const Blob& shader) = 0;
+				virtual void MSSetNodeMask(uint32_t nodeMask) = 0;
+				virtual void DispatchMesh(uint32_t ThreadGroupCountX, uint32_t ThreadGroupCountY, uint32_t ThreadGroupCountZ) const = 0;
+
+				static uptr MakeUnique(API api = API::DIRECTX_12);
+				static sptr MakeShared(API api = API::DIRECTX_12);
+				static uptr MakeUnique(Ultimate::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
+					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
+					API api = API::DIRECTX_12);
+				static sptr MakeShared(Ultimate::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
+					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1,
+					API api = API::DIRECTX_12);
+			};
+		}
+	}
+}

--- a/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.h
+++ b/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.h
@@ -65,6 +65,10 @@ namespace XUSG
 					const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
 					uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces,
 					uint32_t maxTLASSrvs, uint32_t spaceTLAS);
+				bool createComputePipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
+					const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
+					uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces,
+					uint32_t maxTLASSrvs, uint32_t spaceTLAS);
 
 				Resource* needScratch(uint32_t size);
 


### PR DESCRIPTION
1. Reduce duplicated code for graphics pipeline layout creations.
2. Sketch XUSGUltimate interfaces.
3. Tiny trivial adjustments and fixes.