### PR TITLE
Mesh shader EZ

### DIFF
--- a/XUSG-EZ/XUSG-EZ_DX12.h
+++ b/XUSG-EZ/XUSG-EZ_DX12.h
@@ -189,9 +189,7 @@ namespace XUSG
 
 			static const uint8_t CbvSrvUavTypes = 3;
 
-			bool createPipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
-				const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
-				uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces);
+			bool init(XUSG::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize);
 			bool createGraphicsPipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
 				const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
 				uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces);

--- a/XUSG-EZ/XUSGUltimate-EZ_DX12.h
+++ b/XUSG-EZ/XUSGUltimate-EZ_DX12.h
@@ -19,7 +19,7 @@ namespace XUSG
 			{
 			public:
 				CommandList_DX12();
-				CommandList_DX12(XUSG::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
+				CommandList_DX12(Ultimate::CommandList* pCommandList, uint32_t samplerPoolSize, uint32_t cbvSrvUavPoolSize,
 					uint32_t maxSamplers = 16, const uint32_t* pMaxCbvsEachSpace = nullptr, const uint32_t* pMaxSrvsEachSpace = nullptr,
 					const uint32_t* pMaxUavsEachSpace = nullptr, uint32_t maxCbvSpaces = 1, uint32_t maxSrvSpaces = 1, uint32_t maxUavSpaces = 1);
 				virtual ~CommandList_DX12();
@@ -60,7 +60,7 @@ namespace XUSG
 				Ultimate::CommandList* AsUltimateCommandList() { return dynamic_cast<Ultimate::CommandList*>(this); }
 
 			protected:
-				enum Stage : uint8_t
+				enum StageIndex : uint8_t
 				{
 					PS,
 					MS,
@@ -69,12 +69,11 @@ namespace XUSG
 					NUM_STAGE
 				};
 
-				bool createPipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
-					const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
-					uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces);
 				bool createMeshShaderPipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
 					const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
 					uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces);
+
+				const Shader::Stage& getShaderStage(uint8_t index) const;
 
 				MeshShader::PipelineCache::uptr m_meshShaderPipelineCache;
 
@@ -83,7 +82,7 @@ namespace XUSG
 				MeshShader::State::uptr m_meshShaderState;
 				bool m_isMSStateDirty;
 
-				std::vector<uint32_t> m_meshShaderSpaceToParamIndexMap[Stage::NUM_STAGE][CbvSrvUavTypes];
+				std::vector<uint32_t> m_meshShaderSpaceToParamIndexMap[NUM_STAGE][CbvSrvUavTypes];
 			};
 		}
 	}

--- a/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.h
+++ b/XUSGRayTracing-EZ/XUSGRayTracing-EZ_DX12.h
@@ -61,10 +61,6 @@ namespace XUSG
 				RayTracing::CommandList* AsRTCommandList() { return dynamic_cast<RayTracing::CommandList*>(this); }
 
 			protected:
-				bool createPipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
-					const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
-					uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces,
-					uint32_t maxTLASSrvs, uint32_t spaceTLAS);
 				bool createComputePipelineLayouts(uint32_t maxSamplers, const uint32_t* pMaxCbvsEachSpace,
 					const uint32_t* pMaxSrvsEachSpace, const uint32_t* pMaxUavsEachSpace,
 					uint32_t maxCbvSpaces, uint32_t maxSrvSpaces, uint32_t maxUavSpaces,
@@ -85,8 +81,8 @@ namespace XUSG
 				uint32_t m_scratchSize;
 				std::vector<Resource::uptr> m_scratches;
 
-				bool m_isRTStateDirty;
 				RayTracing::State::uptr m_rayTracingState;
+				bool m_isRTStateDirty;
 
 				uint32_t m_asUavCount;
 				std::vector<uint32_t> m_tlasBindingToParamIndexMap;


### PR DESCRIPTION
1. Implement mesh shader pipeline states.
2. Extract the common code to avoid duplicated code.